### PR TITLE
Use LZW compression for cloud optimized TIFFs

### DIFF
--- a/lib/geo_works/derivatives/processors/gdal.rb
+++ b/lib/geo_works/derivatives/processors/gdal.rb
@@ -49,11 +49,11 @@ module GeoWorks
           def self.cloud_optimized_geotiff(in_path, out_path, _options)
             system("gdaladdo -q -r average #{in_path} 2 4 8 16 32")
             execute("gdal_translate -q -expand rgb #{in_path} #{out_path} -co TILED=YES "\
-                      "-co COMPRESS=JPEG -co COPY_SRC_OVERVIEWS=YES")
+                      "-co COMPRESS=LZW -co COPY_SRC_OVERVIEWS=YES")
           rescue StandardError
             # Try without expanding rgb
             execute("gdal_translate -q #{in_path} #{out_path} -co TILED=YES "\
-                      "-co COMPRESS=JPEG -co COPY_SRC_OVERVIEWS=YES")
+                      "-co COMPRESS=LZW -co COPY_SRC_OVERVIEWS=YES")
           end
 
           # Executes a gdal_rasterize command. Used to rasterize vector


### PR DESCRIPTION
- Use LZW as the default compression. JPEG compression is too strict about the band types of the original TIFF.
