### PR TITLE
Return an empty string if raster has no bounds data

### DIFF
--- a/lib/geo_works/derivatives/processors/raster/info.rb
+++ b/lib/geo_works/derivatives/processors/raster/info.rb
@@ -90,6 +90,7 @@ module GeoWorks
             def raster_bounds
               ul = /(?<=Upper Left\s).*?(?=\n)/.match(doc)
               lr = /(?<=Lower Right\s).*?(?=\n)/.match(doc)
+              return '' unless ul && lr
               w, n = extract_coordinates(ul[0])
               e, s = extract_coordinates(lr[0])
 

--- a/spec/geo_works/derivatives/processors/raster/info_spec.rb
+++ b/spec/geo_works/derivatives/processors/raster/info_spec.rb
@@ -50,4 +50,31 @@ RSpec.describe GeoWorks::Derivatives::Processors::Raster::Info do
       end
     end
   end
+
+  context 'when gdalinfo does not return data' do
+    let(:info_doc) { read_test_data_fixture('files/gdalinfo-blank.txt') }
+
+    describe '#driver' do
+      it 'returns an empty string' do
+        expect(processor.driver).to eq('')
+      end
+    end
+
+    describe '#min_max' do
+      it 'returns an empty string' do
+        expect(processor.min_max).to eq('')
+      end
+    end
+
+    describe '#size' do
+      it 'returns an empty string' do
+        expect(processor.size).to eq('')
+      end
+    end
+    describe '#bounds' do
+      it 'returns an empty string' do
+        expect(processor.bounds).to eq('')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes an error when running the raster info processor on datasets that don't have bounds data.

Closes #20 
