### PR TITLE
Rescue errors in raster info processor bounds method

### DIFF
--- a/lib/geo_works/derivatives/processors/raster/info.rb
+++ b/lib/geo_works/derivatives/processors/raster/info.rb
@@ -90,11 +90,12 @@ module GeoWorks
           def raster_bounds
             ul = /(?<=Upper Left\s).*?(?=\n)/.match(doc)
             lr = /(?<=Lower Right\s).*?(?=\n)/.match(doc)
-            return '' unless ul && lr
             w, n = extract_coordinates(ul[0])
             e, s = extract_coordinates(lr[0])
 
             { north: n, east: e, south: s, west: w }
+          rescue StandardError
+            ''
           end
 
           # Given an output string from the gdalinfo command, returns

--- a/spec/fixtures/files/gdalinfo-no-geo-tiff.txt
+++ b/spec/fixtures/files/gdalinfo-no-geo-tiff.txt
@@ -1,0 +1,24 @@
+Driver: GTiff/GeoTIFF
+Files: /example.tif
+Size is 200, 287
+Metadata:
+  TIFFTAG_DATETIME=2014:12:03 12:40:50
+  TIFFTAG_DOCUMENTNAME=color_200.tif
+  TIFFTAG_RESOLUTIONUNIT=2 (pixels/inch)
+  TIFFTAG_SOFTWARE=Adobe Photoshop CS5.1 Macintosh
+  TIFFTAG_XRESOLUTION=1120
+  TIFFTAG_YRESOLUTION=1120
+Image Structure Metadata:
+  INTERLEAVE=PIXEL
+Corner Coordinates:
+Upper Left  (    0.0,    0.0)
+Lower Left  (    0.0,  287.0)
+Upper Right (  200.0,    0.0)
+Lower Right (  200.0,  287.0)
+Center      (  100.0,  143.5)
+Band 1 Block=200x13 Type=Byte, ColorInterp=Red
+    Computed Min/Max=14.000,220.000
+Band 2 Block=200x13 Type=Byte, ColorInterp=Green
+    Computed Min/Max=14.000,209.000
+Band 3 Block=200x13 Type=Byte, ColorInterp=Blue
+    Computed Min/Max=14.000,183.000

--- a/spec/geo_works/derivatives/processors/raster/info_spec.rb
+++ b/spec/geo_works/derivatives/processors/raster/info_spec.rb
@@ -49,31 +49,42 @@ RSpec.describe GeoWorks::Derivatives::Processors::Raster::Info do
                                        west: 74.432166)
       end
     end
-  end
 
-  context 'when gdalinfo does not return data' do
-    let(:info_doc) { read_test_data_fixture('files/gdalinfo-blank.txt') }
+    context 'when gdalinfo does not return data' do
+      let(:info_doc) { read_test_data_fixture('files/gdalinfo-blank.txt') }
 
-    describe '#driver' do
-      it 'returns an empty string' do
-        expect(processor.driver).to eq('')
+      describe '#driver' do
+        it 'returns an empty string' do
+          expect(processor.driver).to eq('')
+        end
+      end
+
+      describe '#min_max' do
+        it 'returns an empty string' do
+          expect(processor.min_max).to eq('')
+        end
+      end
+
+      describe '#size' do
+        it 'returns an empty string' do
+          expect(processor.size).to eq('')
+        end
+      end
+
+      describe '#bounds' do
+        it 'returns an empty string' do
+          expect(processor.bounds).to eq('')
+        end
       end
     end
 
-    describe '#min_max' do
-      it 'returns an empty string' do
-        expect(processor.min_max).to eq('')
-      end
-    end
+    context 'when processor is run against a non-geo tiff' do
+      let(:info_doc) { read_test_data_fixture('files/gdalinfo-no-geo-tiff.txt') }
 
-    describe '#size' do
-      it 'returns an empty string' do
-        expect(processor.size).to eq('')
-      end
-    end
-    describe '#bounds' do
-      it 'returns an empty string' do
-        expect(processor.bounds).to eq('')
+      describe '#bounds' do
+        it 'returns an empty string' do
+          expect(processor.bounds).to eq('')
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ ENV['RAILS_ENV'] = 'test'
 require 'simplecov'
 require 'coveralls'
 require 'fileutils'
+require 'pry-byebug'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
   [


### PR DESCRIPTION
Because of the sheer number of file formats and projections, there are many ways that gdalinfo can return unusual bounds data. This solution is to rescue any bounds parsing errors. In particular, this PR addresses an issue where a tiff without geo headers is passed to the processor.

- Update rubocop config and fix failing cops
- Add rubocop check to Circle CI
- Rescue errors in raster info processor bounds method

Blocked-by: #22  (Rebase this PR after it is merged)
Closes #24 
